### PR TITLE
Prevent edit if no change made to message text

### DIFF
--- a/iris.rb
+++ b/iris.rb
@@ -788,6 +788,8 @@ class Interface
 
     if message_text.length <= 1
       Display.say 'Empty message, not updating...'
+    elsif message_text == message.message
+      Display.say 'No change made, not updating...'
     else
       Message.edit(message_text, message)
       Display.say 'Message edited!'


### PR DESCRIPTION
I found that if you edit a message but make no change, it will disappear as if it were deleted.

I think this is because if you edit a message and make no change, Iris will count that as an edit anyway and add it `.iris.messages` (the Corpus). However, since the payload remains exactly the same, the edit hash of the message will equal the message's own hash. As a result, the value of `Message.show_me?` becomes false, since Iris thinks that there is a different message whose edit hash is the message hash (in which case the message should not be shown), even though it turns out that "other" message is itself.

Instead of making a change to the hashing function, I think the easiest solution is just to disallow edits that don't alter a message's contents. As far as I can tell, this fixes the issue.

Thanks,
Zack